### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "nodejs"
+run = "npm run serve"

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A simple starter project for playing around with Tailwind in a proper PostCSS environment.
 
+[![Run on Repl.it](https://repl.it/badge/github/tailwindcss/playground)](https://repl.it/github/tailwindcss/playground)
+
 To get started:
 
 1. Clone the repository:


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@Kognise/playground-1).